### PR TITLE
JS Tutorial: Fix misaligned indentation in code examples

### DIFF
--- a/tutorials/tutorial-one-javascript.md
+++ b/tutorials/tutorial-one-javascript.md
@@ -133,7 +133,7 @@ Lastly, we close the connection and exit:
 setTimeout(function() {
   connection.close();
   process.exit(0)
-  }, 500);
+}, 500);
 ```
 
 [Here's the whole send.js script](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/javascript-nodejs/src/send.js).
@@ -204,7 +204,7 @@ channel.consume(queue, function(msg) {
   console.log(" [x] Received %s", msg.content.toString());
 }, {
     noAck: true
-  });
+});
 ```
 
 [Here's the whole receive.js script](https://github.com/rabbitmq/rabbitmq-tutorials/blob/main/javascript-nodejs/src/receive.js).


### PR DESCRIPTION
Going through the docs to learn RabbitMQ and noticed these two tiny nitpicks. 